### PR TITLE
feat: add type to dragonfly_scheduler_download_failure_total metrics

### DIFF
--- a/grafana/dashboards/scheduler.json
+++ b/grafana/dashboards/scheduler.json
@@ -548,7 +548,7 @@
       "pluginVersion": "8.3.6",
       "targets": [
         {
-          "expr": "(sum(rate(dragonfly_scheduler_download_total{}[$interval])) -\nsum(rate(dragonfly_scheduler_download_failure_total{}[$interval])))\n/ \nsum(rate(dragonfly_scheduler_download_total{}[$interval]))",
+          "expr": "(sum(rate(dragonfly_scheduler_download_total{}[$interval])) -\nsum(rate(dragonfly_scheduler_download_failure_total{type=\"p2p\"}[$interval])))\n/ \nsum(rate(dragonfly_scheduler_download_total{}[$interval]))",
           "format": "time_series",
           "interval": "60",
           "intervalFactor": 1,
@@ -760,7 +760,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(increase(dragonfly_scheduler_download_failure_total{}[$interval])) by (instance)",
+          "expr": "sum(increase(dragonfly_scheduler_download_failure_total{type=\"p2p\"}[$interval])) by (instance)",
           "hide": false,
           "interval": "60",
           "legendFormat": "{{instance}}",


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add type to `dragonfly_scheduler_download_failure_total` metrics.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
