### PR TITLE
chore: rename repo Dragonfly2 to dragonfly

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ based on `grafana/dashboards/manager.json`, `grafana/dashboards/scheduler.json`,
 ## Note to developers
 
 If developers need to publish grafana dashboard to [d7y](https://grafana.com/orgs/d7y) organization,
-please contact [dragonfly maintainers](https://github.com/dragonflyoss/Dragonfly2/blob/main/MAINTAINERS.md).
+please contact [dragonfly maintainers](https://github.com/dragonflyoss/dragonfly/blob/main/MAINTAINERS.md).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a small change to the `README.md` file. The change updates the link to the Dragonfly maintainers page to reflect the correct URL.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R14): Updated the link to the Dragonfly maintainers page to point to the correct URL.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/3714
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
