### PR TITLE
chore: update CODEOWNERS team names to dragonfly-approvers/maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,5 @@
 # standard @username or @org/team-name format. You can also refer to a user by an
 # email address that has been added to their GitHub account, for example user@example.com
 
-*                                          @dragonflyoss/dragonfly2-reviewers
-.github                                    @dragonflyoss/dragonfly2-maintainers
+*                                          @dragonflyoss/dragonfly-approvers
+.github                                    @dragonflyoss/dragonfly-maintainers


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the `.github/CODEOWNERS` file to reflect changes in code ownership assignments. The change ensures that the correct teams are responsible for reviewing and maintaining the repository.

* Updated repository-wide ownership from `@dragonflyoss/dragonfly2-reviewers` to `@dragonflyoss/dragonfly-approvers` for all files.
* Changed ownership of the `.github` directory from `@dragonflyoss/dragonfly2-maintainers` to `@dragonflyoss/dragonfly-maintainers`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
